### PR TITLE
add CA and Client certificate functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ var config = {
   apiKey: "XXXXXX", // required
   pathPrefix: "/myRedminePath",
   protocol: "http",
+  // if using SSL settings, change protocol to https
+  // and set port to 443
+  sslCaCert: '/path/to/root/ca.pem', // defaults to null
+  sslClientCert: '/path/to/client/cert.pem', // defaults to null
+  sslClientKey: '/path/to/client/cert.key' // defaults to null
 }
 var redmineApi = new Redmine(config);
 redmineApi.getIssues()

--- a/lib/redmine.js
+++ b/lib/redmine.js
@@ -4,6 +4,7 @@ var http = require('http')
 	, querystring = require('querystring')
 	, D = require('d.js')
 	, packageJson = require('../package.json')
+	, fs = require('fs')
 ;
 
 function escapeJSONString(key, value) {
@@ -32,6 +33,9 @@ function Redmine(config) {
 		.setBasicAuth(config.basicAuth || '')
 		.setProtocol(config.protocol || 'http')
 		.setPathPrefix(config.pathPrefix || '/')
+		.setSslCaCert(config.sslCaCert || null)
+		.setSslClientCert(config.sslClientCert || null)
+		.setSslClientKey(config.sslClientKey || null)
 	;
 }
 var proto = {
@@ -60,7 +64,37 @@ var proto = {
 		this.pathPrefix = p;
 		return this;
 	}
-	, getPathPrefix: function(){ return this.pathPrefix;}
+	, getPathPrefix: function(){ return this.pathPrefix; }
+	, setSslCaCert: function(c){
+		if (c !== null){
+			this.sslCaCert = fs.readFileSync(c)
+			return this;
+		} else {
+			this.sslCaCert = c;
+			return this;
+		}
+	}
+	, getSslCaCert: function(){ return this.sslCaCert; }
+	, setSslClientCert: function(c){
+		if (c !== null){
+			this.sslClientCert = fs.readFileSync(c)
+			return this;
+		} else {
+			this.sslClientCert = c;
+			return this;
+		}
+	}
+	, getSslClientCert: function(){ return this.sslClientCert; }
+	, setSslClientKey: function(c){
+		if (c !== null){
+			this.sslClientKey = fs.readFileSync(c)
+			return this;
+		} else {
+			this.sslClientKey = c;
+			return this;
+		}
+	}
+	, getSslClientKey: function(){ return this.sslClientKey; }
 	, generatePath: function(path, params) {
 		return path + '?' + querystring.stringify(params||{});
 	}
@@ -79,13 +113,15 @@ var proto = {
 			, port: self.port
 			, path: method === 'GET' ? self.generatePath(path, params) : path
 			, method: method
+			, ca: self.sslCaCert
+			, cert: self.sslClientCert
+			, key: self.sslClientKey
 			, headers: {
 				'X-Redmine-API-Key': self.apiKey
 			}
-			//- ,agent:false
+			, agent:false
 		};
 		self.basicAuth && (options.auth = self.basicAuth);
-
 		req = (self.protocol==='https' ? https : http).request(options, function(res){
 			var body='';
 			res.setEncoding('utf8');


### PR DESCRIPTION
I noticed there was not any custom SSL configuration for this, so I added the feature to enable custom CA certs, as well as Client Cert and Keys.

Since node HTTPS has the variables as null if not defined, I simply defined them as null when not specified in the config.

-Eric
