### PR TITLE
add DisableSslV3 feature to allow authenticated communication with TL…

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Main methods
   - **(get|set)BasicAuth(auth)** string used as *auth* option of the http request
   - **(get|set)Protocol(protocol)** http or https
   - **(get|set)PathPrefix(prefix)** path prefix to prepend to each request paths
+  - **(get|set)sslV3Disabled(boolean)** boolean value to disable the use of SSLv3 with the secureOptions 'SSL_OP_NO_SSLv3' flag. Defaults to false
   - **(get|set)SslCaCert(certFilePath)** path or array of path to authority certificates files to check the remote host against
   - **(get|set)SslClientCert(certFilePath)** path to public x509 certificate file to use
   - **setSslClientKey(keyFilePath, passPhrase)*** path to client private key file to use for SSL and associated passphrase

--- a/lib/redmine.js
+++ b/lib/redmine.js
@@ -39,6 +39,7 @@ function Redmine(config) {
 		.setPort(config.port || (config.protocol === 'https' ? 443 : 80))
 		.setBasicAuth(config.basicAuth || '')
 		.setPathPrefix(config.pathPrefix || '/')
+		.setSslV3Disabled(config.sslV3Disabled || false)
 		.setSslCaCert(config.sslCaCert || null)
 		.setSslClientCert(config.sslClientCert || null)
 		.setSslClientKey(config.sslClientKey || null, config.sslClientPassphrase || null)
@@ -73,6 +74,11 @@ var proto = {
 		return this;
 	}
 	, getPathPrefix: function(){ return this.pathPrefix; }
+	, setSslV3Disabled: function(b){
+		this.sslV3Disabled = b ? 'SSL_OP_NO_SSLv3' : null;
+		return this;
+	}
+	, getSslV3Disabled: function(){ return this.sslV3Disabled;}
 	, setSslCaCert: function(c){ this.sslCaCert = c ? splitca(c) : null; return this; }
 	, getSslCaCert: function(){ return this.sslCaCert; }
 	, setSslClientCert: function(c){ this.sslClientCert = c ? fs.readFileSync(c) : null; return this; }
@@ -140,6 +146,7 @@ var proto = {
 		self.basicAuth && (options.auth = self.basicAuth);
 		self.sslCaCert && (options.ca = self.sslCaCert);
 		self.sslClientCert && (options.cert = self.sslClientCert);
+		self.sslV3Disabled && (options.secureOptions = self.sslV3Disabled);
 		keyPass.key && (options.key = keyPass.key);
 		keyPass.passphrase && (options.passphrase = keyPass.passphrase);
 


### PR DESCRIPTION
add DisableSslV3 feature to allow authenticated communication with TLSv1+ only redmine servers

I kept running into issues with my internal Redmine being explicitly TLSv1+. Fortunately Node gives you an easy way to fix it :smiley: 
