### PR TITLE
Add support for http status code 204

### DIFF
--- a/lib/redmine.js
+++ b/lib/redmine.js
@@ -150,7 +150,7 @@ var proto = {
 				body += chunk;
 			});
 			res.on('end', function() {
-				if( !~([200,201]).indexOf(res.statusCode) ){
+				if( !~([200,201,204]).indexOf(res.statusCode) ){
 					verbose && console.log('STATUSCODE REJECTION:', res.statusCode, '\n' + body);
 					d.reject('STATUSCODE_REJECTION ' + res.statusCode);
 					return;

--- a/test/redmine.test.js
+++ b/test/redmine.test.js
@@ -56,6 +56,16 @@ describe('have a request method which', function() {
 		;
 		expectDummy(redmineApi.request('get', '/testRetry', {retry: {maxTry: 3, maxDelay: 50}}), done);
 	});
+
+  [200,201,204].forEach(function(httpCode){
+    it('should resolve if http status code is '  + httpCode, function(done) {
+      mockServer.get('/myRedminePath/testApiKey')
+        .reply(httpCode, dummyObj)
+      ;
+      expectDummy(redmineApi.request('get', '/testApiKey'), done);
+    });
+  });
+
 });
 
 describe('have a get method which', function(){


### PR DESCRIPTION
Resolve if Redmine responds with an http status code 204 (= no content).

I tested this package with Redmine 4.2.1 and I got a status code 204 back for successful updates which was treated as an error case in the `request` method. 
This PR adds support for 204 status codes. 

Would be nice if you could publish a new version of this package. 
